### PR TITLE
feat(cursor): add fallible try_from_doc_id constructor

### DIFF
--- a/crates/cursor/src/lib.rs
+++ b/crates/cursor/src/lib.rs
@@ -31,12 +31,31 @@ impl Cursor {
     /// Construct a cursor from a document ID with no key values.
     /// Used when no index is available — the planner falls back to
     /// docID-based iteration.
+    ///
+    /// The ID is not validated: an empty ID encodes fine but `decode`
+    /// rejects it with `EmptyDocId`. Prefer `try_from_doc_id` when the
+    /// ID comes from an untrusted source.
     pub fn from_doc_id(doc_id: impl Into<String>) -> Self {
         Self {
             doc_id: doc_id.into(),
             keys: BTreeMap::new(),
             direction: String::new(),
         }
+    }
+
+    /// Fallible variant of `from_doc_id` that rejects an empty document
+    /// ID with `EmptyDocId` instead of producing a token `decode`
+    /// would refuse.
+    pub fn try_from_doc_id(doc_id: impl Into<String>) -> Result<Self, CursorError> {
+        let doc_id = doc_id.into();
+        if doc_id.is_empty() {
+            return Err(CursorError::EmptyDocId);
+        }
+        Ok(Self {
+            doc_id,
+            keys: BTreeMap::new(),
+            direction: String::new(),
+        })
     }
 
     /// Encode to a base64url-no-pad token: `base64url(json{d, k, o})`.

--- a/crates/cursor/tests/codec.rs
+++ b/crates/cursor/tests/codec.rs
@@ -50,6 +50,20 @@ fn decode_rejects_empty_doc_id() {
 }
 
 #[test]
+fn try_from_doc_id_rejects_empty() {
+    let err = Cursor::try_from_doc_id("").unwrap_err();
+    assert!(matches!(err, CursorError::EmptyDocId));
+}
+
+#[test]
+fn try_from_doc_id_round_trips() {
+    let c = Cursor::try_from_doc_id("doc-1").unwrap();
+    let token = c.encode();
+    let decoded = Cursor::decode(&token).unwrap();
+    assert_eq!(decoded.doc_id, "doc-1");
+}
+
+#[test]
 fn encode_omits_empty_keys() {
     let c = Cursor::from_doc_id("doc-1");
     let token = c.encode();


### PR DESCRIPTION
**Gap:** `Cursor::from_doc_id` (`crates/cursor/src/lib.rs`) accepts any string including empty, but `Cursor::decode` rejects an empty doc ID with `EmptyDocId`. So `from_doc_id("").encode()` succeeds yet the resulting token fails `decode` a page later with an opaque error instead of failing at construction.

**Fix (non-breaking):** add `try_from_doc_id` returning `Err(CursorError::EmptyDocId)` for empty input; keep `from_doc_id` unchanged and document the asymmetry on it so existing callers (planner fallback, tests) are unaffected.

**Tests:** added `try_from_doc_id_rejects_empty` and `try_from_doc_id_round_trips` to `crates/cursor/tests/codec.rs`.

**Verified:**
- `cargo test -p cursor` — all pass (9 codec + 2 go_fixtures)
- `cargo clippy -p cursor --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean